### PR TITLE
Remove parameters from Game constructor

### DIFF
--- a/src/main/java/com/questquest/Game.java
+++ b/src/main/java/com/questquest/Game.java
@@ -18,10 +18,10 @@ public class Game extends Thread {
     private Player currentPlayer;
     private Scanner scanner;
 
-    public Game(Player currentPlayer, int startingLocation) {
-        this.currentPlayer = currentPlayer;
+    public Game() {
+        this.currentPlayer = new Player(0, "Lonk", null);
         this.locations = initializeLocations();
-        this.currentLocationID = startingLocation;
+        this.currentLocationID = 0;
         this.currentExits = locations.get(currentLocationID).getExits();
 
     }

--- a/src/main/java/com/questquest/Main.java
+++ b/src/main/java/com/questquest/Main.java
@@ -6,8 +6,7 @@ public class Main {
     public static Player currentPlayer;
 
     public static void main(String[] args) {
-        currentPlayer = new Player(0, "Lonk", null);
-        Game game = new Game(currentPlayer, 0);
+        Game game = new Game();
         game.start();
     }
 


### PR DESCRIPTION
Now that Game extends Thread, there is no need for it to be passed a Player as a parameter, as there is no scenario where a Player needs to be accessed outside of the scope of a Game or accessed by multiple Game instances.